### PR TITLE
[TOOLS-4363] Mapping page message error for table's PK (#54)

### DIFF
--- a/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/utils/MigrationCfgUtils.java
+++ b/com.cubrid.cubridmigration.ui/src/com/cubrid/cubridmigration/ui/wizard/utils/MigrationCfgUtils.java
@@ -324,6 +324,7 @@ public class MigrationCfgUtils {
 	 */
 	protected VerifyResultMessages checkEntryTableCfg(MigrationConfiguration config,
 			SourceEntryTableConfig setc) {
+				
 		//If don't create and don't migrate data, ignore it
 		if (!setc.isCreateNewTable() && !setc.isMigrateData()) {
 			return new VerifyResultMessages();
@@ -917,19 +918,27 @@ public class MigrationCfgUtils {
 	 */
 	public String getNoPKSourceTablesCheckingResult() {
 		StringBuffer sb = new StringBuffer();
+		Table table = null;
 		for (SourceEntryTableConfig setc : config.getExpEntryTableCfg()) {
 			if (!setc.isCreateNewTable() && !setc.isMigrateData()) {
 				continue;
 			}
-			if (sb.length() > 0) {
-				sb.append(", ");
+			
+			table = config.getSrcTableSchema(setc.getOwner(), setc.getName());
+
+			if (!table.hasPK()) {
+				if (config.getSrcCatalog().getSchemas().size() > 1) {
+					sb.append(table.getSchema().getName()).append(".");
+				}
+
+				sb.append(setc.getName()).append(", ");
 			}
-			sb.append(setc.getName());
 		}
 		if (sb.length() == 0) {
 			return "";
 		}
-		return NLS.bind(Messages.objectMapPageErrMsgNoPK, sb.toString());
+		
+		return NLS.bind(Messages.objectMapPageErrMsgNoPK, sb.toString().replaceAll(", $", ""));
 	}
 
 	public boolean checkMultipleSchema(Catalog catalog, MigrationConfiguration cfg) {


### PR DESCRIPTION
* [TOOLS-4363] Mapping page message error for table's PK

http://jira.cubrid.org/browse/TOOLS-4363

- fix tables with PK not to be added to messages.
- if source DB is mulit schema, add schema name as prefix before table
  name.

* [TOOLS-4363] remove unused method

- remove 'isSourceMultiSchema' method